### PR TITLE
iso_url changed by Microsoft (step0-packer-windows-vagrantbox)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ logback.out.xml
 *.box
 step0-packer-windows-vagrantbox/Vagrantfile
 *.ISO
+step0-packer-windows-vagrantbox/packer_cache

--- a/README.md
+++ b/README.md
@@ -82,12 +82,12 @@ If you like to dig deeper into the myriads of configuration options, have a look
 
 #### Build your Windows Server 2016 Vagrant box
 
-Download the [14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO](https://www.microsoft.com/de-de/evalcenter/evaluate-windows-server-2016) and place it into the __/packer__ folder.
+Download the [Windows_Server_2016_Datacenter_EVAL_en-us_14393_refresh.ISO](https://www.microsoft.com/de-de/evalcenter/evaluate-windows-server-2016) and place it into the __/packer__ folder.
 
 Inside the `step0-packer-windows-vagrantbox` directory start the build with this command:
 
 ```
-packer build -var iso_url=14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO -var iso_checksum=70721288bbcdfe3239d8f8c0fae55f1f windows_server_2016_docker.json
+packer build -var iso_url=Windows_Server_2016_Datacenter_EVAL_en-us_14393_refresh.ISO -var iso_checksum=70721288bbcdfe3239d8f8c0fae55f1f windows_server_2016_docker.json
 ```
 
 Now get yourself a coffee. This will take some time ;)

--- a/step0-packer-windows-vagrantbox/packerCommands.sh
+++ b/step0-packer-windows-vagrantbox/packerCommands.sh
@@ -1,6 +1,6 @@
 
 # Run Packer build with Windows Server 2016
-packer build -var iso_url=14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO -var iso_checksum=70721288bbcdfe3239d8f8c0fae55f1f windows_server_2016_docker.json
+packer build -var iso_url=Windows_Server_2016_Datacenter_EVAL_en-us_14393_refresh.ISO -var iso_checksum=70721288bbcdfe3239d8f8c0fae55f1f windows_server_2016_docker.json
 
 # add it to local Vagrant Boxes
 vagrant box add --name windows_2016_multimachine windows_2016_docker_multimachine_virtualbox.box

--- a/step0-packer-windows-vagrantbox/windows_server_2016_docker.json
+++ b/step0-packer-windows-vagrantbox/windows_server_2016_docker.json
@@ -16,15 +16,15 @@
       "post_shutdown_delay": "10s",
       "guest_os_type": "Windows2016_64",
       "guest_additions_mode": "attach",
-      "disk_size": 61440,
+      "disk_size": 50000,
       "floppy_files": [
         "{{user `autounattend_file`}}",
         "./scripts/configure-ansible.ps1",
         "./scripts/oracle-cert.cer"
       ],
       "vboxmanage": [
-        ["modifyvm", "{{.Name}}", "--memory", "4096"],
-        ["modifyvm", "{{.Name}}", "--cpus", "4"],
+        ["modifyvm", "{{.Name}}", "--memory", "2048"],
+        ["modifyvm", "{{.Name}}", "--cpus", "1"],
         ["modifyvm", "{{.Name}}", "--vram", "32"]
       ]
     }

--- a/step0-packer-windows-vagrantbox/windows_server_2016_docker.json
+++ b/step0-packer-windows-vagrantbox/windows_server_2016_docker.json
@@ -53,7 +53,7 @@
     }
   ],
   "variables": {
-    "iso_url": "http://care.dlservice.microsoft.com/dl/download/1/4/9/149D5452-9B29-4274-B6B3-5361DBDA30BC/14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO",
+    "iso_url": "https://software-download.microsoft.com/download/pr/Windows_Server_2016_Datacenter_EVAL_en-us_14393_refresh.ISO",
     "iso_checksum_type": "md5",
     "iso_checksum": "70721288BBCDFE3239D8F8C0FAE55F1F",
     "template_url": "vagrantfile-windows_2016.template",


### PR DESCRIPTION
They changed the iso_url: 
-    "iso_url": "http://care.dlservice.microsoft.com/dl/download/1/4/9/149D5452-9B29-4274-B6B3-5361DBDA30BC/14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO",
+    "iso_url": "https://software-download.microsoft.com/download/pr/Windows_Server_2016_Datacenter_EVAL_en-us_14393_refresh.ISO",
     "iso_checksum_type": "md5",
     "iso_checksum": "70721288BBCDFE3239D8F8C0FAE55F1F",
     "template_url": "vagrantfile-windows_2016.template",
